### PR TITLE
fix(install): bootstrap Homebrew on no-flag install path

### DIFF
--- a/.cross-platform-skiplist
+++ b/.cross-platform-skiplist
@@ -10,6 +10,7 @@ sounds
 vs-cpp
 
 # Linux-only tools (no Windows counterpart)
+brew-bootstrap
 brew-git
 ecs-cli
 git-completion

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When the `agents` repo is cloned as a sibling of the dotfiles repo (e.g. `~/git/
 | `git` | Repo clone; symlinks reference repo paths |
 | `curl` | Bootstrap fetches (nvm, uv, starship, awscli installers) |
 
-> sudo access is required for apt/Homebrew installs (`--base` and above).
+> On macOS, `./install.sh` (no flag) also installs Homebrew if absent (may prompt for admin password). sudo/admin access is required for apt/Homebrew installs (`--base` and above).
 
 ### Required (Windows)
 
@@ -71,13 +71,15 @@ Note: no-flag install also sets up a Node.js version manager (nvm on Linux/macOS
 # The `agents` and `dotfiles-private` repos must be siblings of this one.
 git clone git@github.com:nirecom/dotfiles.git ~/git/dotfiles
 cd ~/git/dotfiles
-./install.sh            # Symlinks only
+./install.sh            # Symlinks + Homebrew bootstrap (macOS)
 ./install.sh --base     # Symlinks + base packages
 ./install.sh --develop  # Symlinks + dev tools
 ./install.sh --full     # Symlinks + base + dev tools
 ```
 
 `install.sh` resolves its own location and writes `~/.dotfiles_env` so login shells (`.bash_profile`, `.zshrc`) can find the repo regardless of where it was cloned.
+
+On macOS, the no-flag `./install.sh` also ensures Homebrew is usable in the current process: if Homebrew is already installed it applies `brew shellenv`; if absent it installs Homebrew (and Rosetta on Apple Silicon) automatically. This is required because the default install path sets up keychain and gh, both of which need `brew`.
 
 ### Windows (PowerShell)
 

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,11 @@ echo ""
 printf "${C_BOLD}--- Creating symlinks ---${C_RESET}\n"
 "$DOTFILES_DIR/install/linux/dotfileslink.sh"
 
-# Step 2: Install keychain (SSH agent manager)
+# Step 2: Ensure Homebrew is usable in this process (macOS only, no-op elsewhere)
+source "$DOTFILES_DIR/install/linux/brew-bootstrap.sh"
+brew_bootstrap
+
+# Step 3: Install keychain (SSH agent manager)
 echo ""
 printf "${C_BOLD}--- Installing keychain ---${C_RESET}\n"
 "$DOTFILES_DIR/install/linux/keychain.sh"
@@ -77,12 +81,12 @@ if [ "$1" = "--base" ] || [ "$1" = "--develop" ] || [ "$1" = "--full" ]; then
 fi
 
 if [ "$1" = "--develop" ] || [ "$1" = "--full" ]; then
-    # Step 8: Install development tools
+    # Step 10: Install development tools
     echo ""
     printf "${C_BOLD}--- Installing development tools ---${C_RESET}\n"
     "$DOTFILES_DIR/install/linux/install-develop.sh"
 
-    # Step 9: Install VS Code and extensions
+    # Step 11: Install VS Code and extensions
     echo ""
     printf "${C_BOLD}--- Installing Visual Studio Code ---${C_RESET}\n"
     "$DOTFILES_DIR/install/linux/vscode.sh"

--- a/install/linux/brew-bootstrap.sh
+++ b/install/linux/brew-bootstrap.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Homebrew bootstrap — source this file, then call brew_bootstrap explicitly.
+# Sourcing alone has NO side effects. macOS only; no-op on every other OS.
+: "${DOTFILES_DIR:=$(cd "$(dirname "$0")/../.." && pwd)}"
+# shellcheck source=/dev/null
+source "$DOTFILES_DIR/bin/detectos.sh"
+# shellcheck source=/dev/null
+source "$DOTFILES_DIR/bin/colors.sh"
+
+brew_bootstrap() {
+    # shellcheck source=/dev/null
+    source "$DOTFILES_DIR/bin/detectos.sh"
+
+    if [[ "$OSDIST" != "macos" ]]; then
+        return 0
+    fi
+
+    echo ""
+    printf "${C_BOLD}--- Bootstrapping Homebrew ---${C_RESET}\n"
+
+    # Warm path: brew already installed — apply shellenv for this process.
+    if [[ -x /opt/homebrew/bin/brew ]]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [[ -x /usr/local/bin/brew ]]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    else
+        # Cold path: brew genuinely absent.
+        if ! /usr/bin/pgrep -q oahd 2>/dev/null; then
+            echo "Installing Rosetta..."
+            softwareupdate --install-rosetta --agree-to-license
+        else
+            echo "Rosetta is already installed."
+        fi
+
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+        if [[ "$ISM1" == "true" ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        else
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+    fi
+}

--- a/install/linux/brew-git.sh
+++ b/install/linux/brew-git.sh
@@ -8,29 +8,10 @@ if [ "$OSDIST" != "macos" ]; then
     exit 1
 fi
 
-if ! /usr/bin/pgrep -q oahd 2>/dev/null; then
-    echo "Installing Rosetta..."
-    softwareupdate --install-rosetta --agree-to-license
-else
-    echo "Rosetta is already installed."
-fi
-
-# Install Brew on macos
-if ! type brew >/dev/null 2>&1; then
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-# brew shellenv will be done at .profile_common under dotfiles/ repository
-#    if [ ! grep "$BREWPATH" $HOME/.profile >/dev/null 2&>1 ]; then
-#        echo 'eval $(/opt/homebrew/bin/brew shellenv)' >>$HOME/.profile
-#    fi
-#    if [ ! grep "$BREWPATH" $HOME/.profile >/dev/null 2&>1 ]; then
-#        echo 'eval $(/opt/homebrew/bin/brew shellenv)' >>$HOME/.zprofile
-#    fi
-fi
-if "$ISM1"; then
-    eval $(/opt/homebrew/bin/brew shellenv)
-else
-    eval $(/usr/local/bin/brew shellenv)
-fi
+# Ensure brew is installed and usable in this process (Rosetta + installer + shellenv).
+# shellcheck source=/dev/null
+source "$DOTFILES_DIR/install/linux/brew-bootstrap.sh"
+brew_bootstrap
 
 # two dependencies of git
 # https://github.com/Homebrew/discussions/discussions/439

--- a/install/linux/gh.sh
+++ b/install/linux/gh.sh
@@ -31,5 +31,9 @@ else
     printf "${C_GREEN}gh installed: $(gh --version | head -1)${C_RESET}\n"
 fi
 
-printf "${C_YELLOW}gh: not authenticated — running gh auth login...${C_RESET}\n"
-gh auth login
+if command -v gh >/dev/null 2>&1; then
+    printf "${C_YELLOW}gh: not authenticated — running gh auth login...${C_RESET}\n"
+    gh auth login || printf "${C_YELLOW}gh auth login did not complete; continuing installation.${C_RESET}\n"
+else
+    printf "${C_YELLOW}gh not available — skipping gh auth login.${C_RESET}\n"
+fi

--- a/tests/main-brew-bootstrap.sh
+++ b/tests/main-brew-bootstrap.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# tests/main-brew-bootstrap.sh - Tests for install/linux/brew-bootstrap.sh
+# Tests: install/linux/brew-bootstrap.sh, install.sh
+# Tags: installer, homebrew, brew-bootstrap, macos, scope:common, pwsh-not-required
+#
+# The unit under test does NOT exist yet (issue #331 fix). It is a SOURCED unit
+# defining a `brew_bootstrap` function. Static + dynamic tests skip gracefully
+# until the file is created (fail-before-fix: pending-implementation skips are
+# the current-state signal for this brand-new unit).
+#
+# L3 gap (what this test does NOT catch):
+# - Warm-path branch SELECTION between /opt/homebrew (Apple Silicon) and
+#   /usr/local (Intel) cannot be faithfully forced in CI: the unit hardcodes
+#   those absolute paths, which cannot be mocked under a temp dir without root.
+#   The best-effort warm-path test below only runs on a real Mac that already
+#   has brew at one of those prefixes; it cannot assert which branch was taken.
+# - Cold path (real Rosetta install via softwareupdate + the official Homebrew
+#   installer via curl) is destructive/network-bound and only verifiable on real
+#   macOS hardware with Homebrew genuinely absent.
+# Closest-to-action mitigation: this gap is checked at WORKFLOW_USER_VERIFIED
+# preflight via bin/check-verification-gate.sh category: installer.
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$DOTFILES_DIR/install/linux/brew-bootstrap.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1 (source unit not yet created)"; SKIP=$((SKIP + 1)); }
+
+# Global temp dir — cleaned on exit
+TMPBASE=$(mktemp -d)
+trap "rm -rf '$TMPBASE'" EXIT
+
+# ---------------------------------------------------------------------------
+# Portable timeout wrapper (macOS lacks the timeout command)
+# ---------------------------------------------------------------------------
+run_with_timeout() {
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 120 "$@"
+    else
+        perl -e 'alarm 120; exec @ARGV' -- "$@"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# STATIC TESTS — assert the planned contract of brew-bootstrap.sh.
+# Table-driven: one required grep pattern per row (test-design table pattern).
+# Skips entirely when the unit does not exist yet.
+# ---------------------------------------------------------------------------
+echo "=== Static: brew-bootstrap.sh planned contract ==="
+if [ ! -f "$SCRIPT" ]; then
+    skip "static contract checks — brew-bootstrap.sh absent"
+else
+    while IFS='|' read -r name pattern; do
+        [[ -z "$name" || "$name" =~ ^[[:space:]]*# ]] && continue
+        name="${name//[[:space:]]/}"
+        pattern="${pattern#"${pattern%%[![:space:]]*}"}"   # ltrim
+        pattern="${pattern%"${pattern##*[![:space:]]}"}"   # rtrim
+        if grep -Eq "$pattern" "$SCRIPT"; then
+            pass "static: $name"
+        else
+            fail "static: $name (pattern /$pattern/ not found)"
+        fi
+    done <<'TABLE'
+defines-brew_bootstrap-function | brew_bootstrap\s*\(\)
+sources-detectos               | detectos\.sh
+non-macos-returns-0            | return 0
+prints-bootstrap-header        | Bootstrapping Homebrew
+warm-apple-silicon-path        | /opt/homebrew/bin/brew
+warm-intel-path                | /usr/local/bin/brew
+applies-shellenv               | brew shellenv
+cold-rosetta-precheck          | pgrep.*oahd
+cold-rosetta-install           | softwareupdate --install-rosetta
+cold-official-installer        | Homebrew/install
+TABLE
+
+    # Guard: sourcing must NOT auto-invoke brew_bootstrap. Flag a top-level
+    # (column-0) bare call, which would violate "source has no side effect".
+    if grep -Eq '^brew_bootstrap[[:space:]]*$' "$SCRIPT"; then
+        fail "static: sourcing auto-invokes brew_bootstrap (top-level call present)"
+    else
+        pass "static: no top-level auto-invocation of brew_bootstrap"
+    fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# DYNAMIC BB-1: non-macOS is a no-op — returns 0, prints no header, invokes no
+# installer commands (softwareupdate / curl / brew never called).
+# uname is mocked to report Linux so the unit-sourced detectos.sh yields a
+# non-macOS OSDIST. Fully hermetic; runs on any host once the unit exists.
+# ---------------------------------------------------------------------------
+echo "=== BB-1: non-macOS — no-op, returns 0, no installer calls ==="
+if [ ! -f "$SCRIPT" ]; then
+    skip "BB-1"
+else
+    MOCK="$TMPBASE/bb1"
+    mkdir -p "$MOCK"
+    cat > "$MOCK/uname" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+    -m) echo "x86_64" ;;
+    *)  echo "Linux" ;;
+esac
+EOF
+    for cmd in softwareupdate curl brew pgrep; do
+        cat > "$MOCK/$cmd" <<EOF
+#!/bin/bash
+echo "$cmd" >> "$MOCK/CALLED"
+exit 0
+EOF
+    done
+    chmod +x "$MOCK"/*
+
+    output=$(run_with_timeout env PATH="$MOCK:$PATH" DOTFILES_DIR="$DOTFILES_DIR" \
+        bash -c 'source "$1"; brew_bootstrap; echo "RC=$?"' _ "$SCRIPT" 2>&1) \
+        && exit_code=$? || exit_code=$?
+
+    ok=1
+    echo "$output" | grep -q 'RC=0' || ok=0
+    [ "$exit_code" -eq 0 ] || ok=0
+    if echo "$output" | grep -qi 'Bootstrapping Homebrew'; then ok=0; fi
+    if [ -f "$MOCK/CALLED" ]; then ok=0; fi
+
+    if [ "$ok" -eq 1 ]; then
+        pass "BB-1: non-macOS returns 0, no header, no installer invocation"
+    else
+        called="$( [ -f "$MOCK/CALLED" ] && tr '\n' ',' < "$MOCK/CALLED" || echo none )"
+        fail "BB-1: exit=$exit_code called=[$called] output=[$output]"
+    fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# DYNAMIC BB-2: idempotent source — sourcing defines the function but does NOT
+# invoke it. Verified by declare -F plus absence of any installer sentinel.
+# uname mocked to Darwin so an accidental invocation WOULD hit the brew sentinel.
+# ---------------------------------------------------------------------------
+echo "=== BB-2: sourcing does not auto-invoke brew_bootstrap ==="
+if [ ! -f "$SCRIPT" ]; then
+    skip "BB-2"
+else
+    MOCK="$TMPBASE/bb2"
+    mkdir -p "$MOCK"
+    cat > "$MOCK/uname" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+    -m) echo "arm64" ;;
+    *)  echo "Darwin" ;;
+esac
+EOF
+    cat > "$MOCK/brew" <<EOF
+#!/bin/bash
+echo "brew" >> "$MOCK/CALLED"
+exit 0
+EOF
+    chmod +x "$MOCK"/*
+
+    output=$(run_with_timeout env PATH="$MOCK:$PATH" DOTFILES_DIR="$DOTFILES_DIR" \
+        bash -c 'source "$1"; declare -F brew_bootstrap >/dev/null && echo DEFINED' _ "$SCRIPT" 2>&1) \
+        && exit_code=$? || exit_code=$?
+
+    if echo "$output" | grep -q 'DEFINED' && [ ! -f "$MOCK/CALLED" ]; then
+        pass "BB-2: function defined, not invoked at source time"
+    else
+        called="$( [ -f "$MOCK/CALLED" ] && cat "$MOCK/CALLED" || echo none )"
+        fail "BB-2: exit=$exit_code called=[$called] output=[$output]"
+    fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# DYNAMIC BB-3: warm-path best-effort (real macOS with brew already present).
+# Cannot mock the hardcoded absolute paths without root, so this only runs on a
+# real Mac that already has brew at /opt/homebrew or /usr/local. The real
+# contract asserted here is that shellenv was APPLIED (HOMEBREW_PREFIX exported
+# into the caller's env). The decorative "--- Bootstrapping Homebrew ---" header
+# is intentionally NOT asserted here: it renders only under a TTY (C_BOLD is
+# empty when stdout is captured), and its presence in the source is already
+# covered by the static contract table above. Skips on Linux CI / a Mac without
+# brew. See the file-header L3 gap block.
+# ---------------------------------------------------------------------------
+echo "=== BB-3: warm-path applies shellenv (real macOS only) ==="
+if [ ! -f "$SCRIPT" ]; then
+    skip "BB-3"
+elif [ "$(uname -s)" != "Darwin" ]; then
+    echo "  SKIP: BB-3 (not macOS — warm-path is hardware-specific)"
+    SKIP=$((SKIP + 1))
+elif [ ! -x /opt/homebrew/bin/brew ] && [ ! -x /usr/local/bin/brew ]; then
+    echo "  SKIP: BB-3 (no brew at a known absolute prefix on this host)"
+    SKIP=$((SKIP + 1))
+else
+    output=$(run_with_timeout env DOTFILES_DIR="$DOTFILES_DIR" \
+        bash -c 'source "$1"; brew_bootstrap; echo "PREFIX=${HOMEBREW_PREFIX:-unset}"' _ "$SCRIPT" 2>&1) \
+        && exit_code=$? || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ] && echo "$output" | grep -q 'PREFIX=/'; then
+        pass "BB-3: warm-path exports HOMEBREW_PREFIX (shellenv applied)"
+    else
+        fail "BB-3: exit=$exit_code output=[$output]"
+    fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# SKIPPED-Because — scenarios not implementable at this test layer.
+# ---------------------------------------------------------------------------
+# SKIPPED: cold path — real Rosetta install (softwareupdate --install-rosetta)
+#   followed by the official Homebrew installer via curl, then shellenv.
+# Because: destructive + network-bound + requires Homebrew genuinely absent;
+#   L2 cannot run the real installer without mutating the host.
+# L3 gap: only a fresh real Mac (Apple Silicon and Intel separately) exercises
+#   the Rosetta precheck branch and the correct post-install shellenv prefix.
+#
+# SKIPPED: warm-path branch SELECTION (Apple Silicon /opt/homebrew vs Intel
+#   /usr/local) when both/neither are present.
+# Because: the unit hardcodes those absolute paths; a temp-dir mock is never on
+#   the code path, and writing under /opt or /usr/local needs root in CI.
+# L3 gap: real hardware of each architecture is required to confirm the correct
+#   prefix is chosen and shellenv exported.
+
+# ---------------------------------------------------------------------------
+# SUMMARY
+# ---------------------------------------------------------------------------
+echo "=== Results: $PASS passed, $FAIL failed, $SKIP skipped ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/main-gh.sh
+++ b/tests/main-gh.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
 # tests/main-gh.sh - Tests for install/linux/gh.sh
+# Tests: install/linux/gh.sh, install.sh
+# Tags: installer, gh, github-cli, auth, scope:common, pwsh-not-required
 # Tests are divided into:
 #   - Static: grep-based pattern checks (run even when script does not exist)
 #   - Dynamic: actual script execution with mocked commands
 # Dynamic tests skip gracefully when the source script is not yet created.
+#
+# FAIL-BEFORE-FIX (issue #331): GH-L-6, GH-L-7 and the auth-guard static checks
+# assert the POST-FIX contract (gh auth login guarded by `command -v gh` and
+# non-fatalized with `||`). Against the current UNFIXED gh.sh they are EXPECTED
+# TO FAIL — that failure is the fail-before-fix evidence, not a test defect.
+# They pass once install/linux/gh.sh Step 4 (guard + non-fatalization) lands.
+#
+# L3 gap: real APT/GPG key injection and sources.list.d modification cannot be
+# tested at L2 (they would mutate the host). Real `gh auth login` interactive
+# TTY/device-flow and network access to packages.github.com are also out of scope.
 
 set -euo pipefail
 
@@ -161,6 +173,29 @@ else
     else
         fail "missing C_GREEN color variable"
     fi
+
+    # --- FAIL-BEFORE-FIX static contract (issue #331 Step 4) ---
+    # GH-S-1: `gh auth login` must be guarded by an ADDITIONAL `command -v gh`
+    # presence check so it is never invoked when gh is absent (brew install
+    # failed). The unfixed script already has ONE `command -v gh` (the install
+    # idempotency check at the top); the auth guard adds a SECOND. So require at
+    # least two occurrences. EXPECTED TO FAIL against current unfixed gh.sh
+    # (exactly one `command -v gh`).
+    cmd_v_gh_count=$(grep -Ec 'command -v gh' "$SCRIPT")
+    if [ "$cmd_v_gh_count" -ge 2 ] && grep -q 'gh auth login' "$SCRIPT"; then
+        pass "GH-S-1: gh auth login is guarded by a dedicated command -v gh check"
+    else
+        fail "GH-S-1 (fail-before-fix): auth login lacks a dedicated command -v gh guard (count=$cmd_v_gh_count)"
+    fi
+
+    # GH-S-2: `gh auth login` must be non-fatalized with `||` so a failed/aborted
+    # login does not propagate up and abort install.sh (which runs under set -e).
+    # EXPECTED TO FAIL against current unfixed gh.sh.
+    if grep -Eq 'gh auth login[[:space:]]*\|\|' "$SCRIPT"; then
+        pass "GH-S-2: gh auth login is non-fatalized with ||"
+    else
+        fail "GH-S-2 (fail-before-fix): gh auth login is not non-fatalized with ||"
+    fi
 fi
 
 echo ""
@@ -170,14 +205,15 @@ echo ""
 # All dynamic tests skip gracefully when the script doesn't exist yet.
 # ---------------------------------------------------------------------------
 
-# GH-L-2: When gh is already installed, prints gray "already installed" and exits 0
-echo "=== GH-L-2: Already installed — prints gray message, exits 0 ==="
+# GH-L-2: When gh is already installed AND authenticated, prints gray
+# "already installed" and exits 0 (early-exit path).
+echo "=== GH-L-2: Already installed + authenticated — exits 0 ==="
 if [ ! -f "$SCRIPT" ]; then
     skip "GH-L-2"
 else
     MOCK_L2="$TMPBASE/mock_l2"
     make_mock_env "$MOCK_L2"
-    make_gh_mock "$MOCK_L2"  # gh IS present
+    make_gh_mock "$MOCK_L2"  # gh IS present; `auth status` returns 0 (exit 0 stub)
 
     output=$(run_with_timeout env PATH="$MOCK_L2:$PATH" DOTFILES_DIR="$DOTFILES_DIR" bash "$SCRIPT" 2>&1) \
         && exit_code=$? || exit_code=$?
@@ -279,7 +315,7 @@ EOF
     if [ "$exit_code" -eq 0 ]; then
         pass "GH-L-1: exits 0 on successful install (ubuntu)"
     else
-        fail "GH-L-1: exits $exit_code; output=[$output]"
+        fail "GH-L-1 (fail-before-fix): exits $exit_code; output=[$output]"
     fi
 fi
 
@@ -352,6 +388,103 @@ else
         fail "GH-L-5: ANSI codes found in piped output: [$output]"
     else
         pass "GH-L-5: no ANSI codes when stdout is piped"
+    fi
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# GH-L-6 (FAIL-BEFORE-FIX, issue #331): gh present but NOT authenticated, and
+# `gh auth login` FAILS (non-zero). The installer must NOT abort — gh.sh must
+# still exit 0 so install.sh (set -e) continues.
+#
+# Current UNFIXED gh.sh ends with a bare `gh auth login`; when it returns
+# non-zero the script exits non-zero → this test FAILS now (expected).
+# After Step 4 adds `gh auth login || printf ...`, gh.sh exits 0 → PASSES.
+# ---------------------------------------------------------------------------
+echo "=== GH-L-6: gh auth login fails — gh.sh stays non-fatal (exit 0) ==="
+if [ ! -f "$SCRIPT" ]; then
+    skip "GH-L-6"
+else
+    MOCK_L6="$TMPBASE/mock_l6"
+    make_mock_env "$MOCK_L6"
+
+    # gh present; `auth status` fails (not authenticated → no early exit),
+    # `auth login` fails (non-zero). Never prompts (returns immediately).
+    cat > "$MOCK_L6/gh" <<'EOF'
+#!/bin/bash
+case "${1:-}" in
+    --version) echo "gh version 2.40.0 (2024-01-01)"; exit 0 ;;
+    auth)
+        case "${2:-}" in
+            status) exit 1 ;;   # NOT authenticated
+            login)  exit 1 ;;   # login FAILS / aborted
+        esac
+        ;;
+esac
+exit 0
+EOF
+    chmod +x "$MOCK_L6/gh"
+
+    output=$(run_with_timeout env PATH="$MOCK_L6:$PATH" DOTFILES_DIR="$DOTFILES_DIR" bash "$SCRIPT" 2>&1) \
+        && exit_code=$? || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "GH-L-6: gh.sh exits 0 despite gh auth login failing"
+    else
+        fail "GH-L-6 (fail-before-fix): gh.sh aborted with exit $exit_code; output=[$output]"
+    fi
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# GH-L-7 (FAIL-BEFORE-FIX, issue #331): gh command genuinely absent (brew/apt
+# install produced no real binary). `gh auth login` must be SKIPPED (guarded by
+# command -v gh) and the script must not abort.
+#
+# Current UNFIXED gh.sh runs `gh auth login` unconditionally → with gh absent it
+# is "command not found" (127) → gh.sh exits non-zero → this test FAILS now.
+# After Step 4 the `command -v gh` guard skips auth → gh.sh exits 0 → PASSES.
+# ---------------------------------------------------------------------------
+echo "=== GH-L-7: gh absent — auth login skipped, script does not abort ==="
+if [ ! -f "$SCRIPT" ]; then
+    skip "GH-L-7"
+else
+    MOCK_L7="$TMPBASE/mock_l7"
+    make_mock_env "$MOCK_L7"   # brew/apt are no-op → gh never becomes available
+
+    # Wrapper forces `command -v gh` to always fail (gh truly absent) so gh.sh
+    # takes the install branch, then reaches the auth section with gh missing.
+    GH_WRAPPER_L7="$TMPBASE/gh_wrapper_l7.sh"
+    cat > "$GH_WRAPPER_L7" <<EOF
+#!/bin/bash
+command() {
+    if [ "\${1:-}" = "-v" ] && [ "\${2:-}" = "gh" ]; then
+        return 1  # gh never found
+    fi
+    builtin command "\$@"
+}
+export -f command
+# Also override gh itself so a real gh on PATH is never reached. Simulate
+# "command not found" (127) WITHOUT prompting — the unfixed script's
+# unconditional 'gh auth login' would otherwise launch the real interactive
+# login and hang. Post-fix, the command -v gh guard skips this entirely.
+gh() { return 127; }
+export -f gh
+export PATH="$MOCK_L7:\$PATH"
+export DOTFILES_DIR="$DOTFILES_DIR"
+source "$SCRIPT"
+EOF
+    chmod +x "$GH_WRAPPER_L7"
+
+    output=$(run_with_timeout bash "$GH_WRAPPER_L7" 2>&1) \
+        && exit_code=$? || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "GH-L-7: gh.sh exits 0 and skips auth login when gh is absent"
+    else
+        fail "GH-L-7 (fail-before-fix): gh.sh aborted with exit $exit_code; output=[$output]"
     fi
 fi
 

--- a/tests/main-installer-idempotency.sh
+++ b/tests/main-installer-idempotency.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 # Test: installer scripts have idempotency checks (skip if already installed)
 # Each script under install/linux/ that installs a tool should check before reinstalling.
+# Tests: install/linux/brew-bootstrap.sh, install/linux/brew-git.sh, install.sh
+# Tags: installer, idempotency, homebrew, orthogonality, scope:common, pwsh-not-required
+#
+# FAIL-BEFORE-FIX (issue #331): the Rosetta idempotency check is asserted against
+# install/linux/brew-bootstrap.sh, which does NOT exist until the #331 fix lands
+# (the Rosetta + official-installer logic moves out of brew-git.sh into the new
+# shared brew-bootstrap.sh unit). Until then this assertion FAILS — that is the
+# fail-before-fix signal, not a test defect.
 
 set -e
 PASS=0
@@ -18,17 +26,28 @@ pass() {
     PASS=$((PASS + 1))
 }
 
-# brew-git.sh: should check Rosetta (pgrep oahd) and git (brew list git)
-if grep -q 'pgrep.*oahd\|arch -x86_64\|rosetta.*installed' "$SCRIPT_DIR/brew-git.sh"; then
-    pass "brew-git.sh has Rosetta idempotency check"
+# brew-bootstrap.sh: owns the Rosetta (pgrep oahd) precheck after #331 moved the
+# bootstrap logic out of brew-git.sh into the shared sourced unit.
+# (Retargeted from brew-git.sh — see file header fail-before-fix note.)
+if grep -q 'pgrep.*oahd\|arch -x86_64\|rosetta.*installed' "$SCRIPT_DIR/brew-bootstrap.sh" 2>/dev/null; then
+    pass "brew-bootstrap.sh has Rosetta idempotency check"
 else
-    fail "brew-git.sh missing Rosetta idempotency check"
+    fail "brew-bootstrap.sh missing Rosetta idempotency check (fail-before-fix: brew-bootstrap.sh not yet created)"
 fi
 
+# brew-git.sh: retains the git idempotency check (git install stays local to it).
 if grep -q 'brew list git\|type git\|command -v git' "$SCRIPT_DIR/brew-git.sh"; then
     pass "brew-git.sh has git idempotency check"
 else
     fail "brew-git.sh missing git idempotency check"
+fi
+
+# brew-git.sh must NOT contain Rosetta logic post-refactor (moved to brew-bootstrap.sh)
+# FAIL-BEFORE-FIX: brew-git.sh retains Rosetta logic until Step 3 of #331 lands.
+if grep -qE 'pgrep.*oahd|softwareupdate.*rosetta' "$SCRIPT_DIR/brew-git.sh" 2>/dev/null; then
+    fail "brew-git.sh still contains Rosetta logic (fail-before-fix: Step 3 refactor not yet landed)"
+else
+    pass "brew-git.sh Rosetta logic correctly removed"
 fi
 
 # tmux.sh: should check if tmux is already installed
@@ -81,11 +100,23 @@ else
 fi
 
 # install.sh: base block must not have macOS special case (orthogonality with install.ps1)
+# Post-#331 the brew bootstrap is invoked UNCONDITIONALLY from install.sh
+# (`source .../brew-bootstrap.sh; brew_bootstrap`) with the macOS guard living
+# INSIDE the sourced unit — so this assertion must continue to hold.
 INSTALL_SH="$DOTFILES_DIR/install.sh"
 if grep -q 'OSDIST.*macos' "$INSTALL_SH"; then
     fail "install.sh has macOS special case in base block (breaks orthogonality)"
 else
     pass "install.sh has no macOS special case (orthogonal with install.ps1)"
+fi
+
+# install.sh must source and call brew_bootstrap (unconditional wiring, post-fix)
+# FAIL-BEFORE-FIX: install.sh does not wire up brew_bootstrap until Step 2 lands.
+INSTALL_SH="$DOTFILES_DIR/install.sh"
+if grep -q 'brew-bootstrap\.sh' "$INSTALL_SH" && grep -q 'brew_bootstrap' "$INSTALL_SH"; then
+    pass "install.sh sources and calls brew_bootstrap (unconditional)"
+else
+    fail "install.sh missing brew_bootstrap wiring (fail-before-fix: Step 2 not yet landed)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- Add `install/linux/brew-bootstrap.sh` shared unit (warm path: `brew shellenv`; cold path: Rosetta + official installer)
- Wire unconditionally into `install.sh` Step 2 before keychain and gh steps
- Refactor `brew-git.sh` to reuse the shared unit
- Guard `gh auth login` with `command -v gh` and make non-fatal
- Update README and `.cross-platform-skiplist`

## Test plan
- [ ] `tests/main-brew-bootstrap.sh` — 14 passed
- [ ] `tests/main-gh.sh` — 19 passed
- [ ] `tests/main-installer-idempotency.sh` — 12 passed
- [ ] `tests/main-keychain-ssh-agent.sh` — 14 passed

Closes #331
<!-- issue-close-pr-of: 331 -->